### PR TITLE
Updated purchase link for AlphaVPS

### DIFF
--- a/data.json
+++ b/data.json
@@ -20,7 +20,7 @@
         "link_url": "https://www.lowendtalk.com/discussion/159825/alphavps-openvz-and-kvm-out-of-5-locations-big-variety-of-dedicated-servers/p1"
       }, {
         "link_desc": "Order",
-        "link_url": "https://alphavps.bg/clients/cart.php?a=confproduct&i=0"
+        "link_url": "https://alphavps.com/clients/store/hdd-kvm-storage-virtual-servers/1024g"
       }],
       "Coupon": "",
       "Note": "EUR 5/m"


### PR DESCRIPTION
The old link seems to just take you to their client area login page. This new link takes you to the actual order page.